### PR TITLE
Synchronize methods 4

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/Cancellable.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Cancellable.java
@@ -35,11 +35,11 @@ public class Cancellable {
 
     static final Cancellable NO_OP = new Cancellable(null) {
         @Override
-        public void cancel() {
+        public synchronized void cancel() {
         }
 
         @Override
-        void runIfNotCancelled(Runnable runnable) {
+        void synchronized runIfNotCancelled(Runnable runnable) {
             throw new UnsupportedOperationException();
         }
     };

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -228,7 +228,7 @@ public class RestClient implements Closeable {
      * Get the list of nodes that the client knows about. The list is
      * unmodifiable.
      */
-    public List<Node> getNodes() {
+    public synchronized List<Node> getNodes() {
         return nodeTuple.nodes;
     }
 

--- a/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRetryingInputStream.java
+++ b/plugins/repository-gcs/src/main/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageRetryingInputStream.java
@@ -246,7 +246,7 @@ class GoogleCloudStorageRetryingInputStream extends InputStream {
     }
 
     @Override
-    public void reset() {
+    public void synchronized reset() {
         throw new UnsupportedOperationException("GoogleCloudStorageRetryingInputStream does not support seeking");
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -88,7 +88,7 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     }
 
     @Override
-    public Throwable getCause() {
+    public synchronized Throwable getCause() {
         Throwable cause = super.getCause();
         if (cause == null) {
             // fall back to guessed root cause

--- a/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NotMasterException.java
@@ -29,7 +29,7 @@ public class NotMasterException extends ElasticsearchException {
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -143,7 +143,7 @@ class BytesReferenceStreamInput extends StreamInput {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         if (sliceStartOffset <= mark) {
             sliceIndex = mark - sliceStartOffset;
         } else {
@@ -162,7 +162,7 @@ class BytesReferenceStreamInput extends StreamInput {
     }
 
     @Override
-    public void mark(int readLimit) {
+    public synchronized void mark(int readLimit) {
         // We ignore readLimit since the data is all in-memory and therefore we can reset the mark no matter how far we advance.
         this.mark = offset();
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteBufferStreamInput.java
@@ -108,7 +108,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         buffer.reset();
     }
 
@@ -125,7 +125,7 @@ public class ByteBufferStreamInput extends StreamInput {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         buffer.mark();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -56,7 +56,7 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         delegate.reset();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -60,7 +60,7 @@ public class InputStreamStreamInput extends StreamInput {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         is.reset();
     }
 
@@ -70,7 +70,7 @@ public class InputStreamStreamInput extends StreamInput {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         is.mark(readlimit);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTask.java
@@ -50,7 +50,7 @@ public abstract class AbstractAsyncTask implements Runnable, Closeable {
         }
     }
 
-    public TimeValue getInterval() {
+    public synchronized TimeValue getInterval() {
         return interval;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -150,13 +150,13 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
     }
 
     @Override
-    protected boolean maybeStall(MergeSource mergeSource) {
+    protected synchronized boolean maybeStall(MergeSource mergeSource) {
         // Don't stall here, because we do our own index throttling (in InternalEngine.IndexThrottle) when merges can't keep up
         return true;
     }
 
     @Override
-    protected MergeThread getMergeThread(MergeSource mergeSource, MergePolicy.OneMerge merge) throws IOException {
+    protected synchronized MergeThread getMergeThread(MergeSource mergeSource, MergePolicy.OneMerge merge) throws IOException {
         MergeThread thread = super.getMergeThread(mergeSource, merge);
         thread.setName(EsExecutors.threadName(indexSettings, "[" + shardId.getIndexName() + "][" + shardId.id() + "]: " +
             thread.getName()));

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2566,7 +2566,7 @@ public class InternalEngine extends Engine {
         }
 
         @Override
-        public long tryDeleteDocument(IndexReader readerIn, int docID) {
+        public synchronized long tryDeleteDocument(IndexReader readerIn, int docID) {
             throw new AssertionError("tryDeleteDocument is not supported. See Lucene#DirectoryReaderWithAllLiveDocs");
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/VersionConflictEngineException.java
@@ -48,7 +48,7 @@ public class VersionConflictEngineException extends EngineException {
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         // This is on the hot path for updates; stack traces are expensive to compute and not very useful for VCEEs, so don't fill it in.
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -134,7 +134,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
         }
 
         @Override
-        public void close() throws IOException {
+        public synchronized void close() throws IOException {
             IOUtils.close(super::close, delegate);
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -442,7 +442,7 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             out.writeVLong(checkIndexTime);
         }
 
-        public void reset() {
+        public synchronized void reset() {
             super.reset();
             checkIndexTime = 0;
         }

--- a/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NodeDisconnectedException.java
@@ -26,7 +26,7 @@ public class NodeDisconnectedException extends ConnectTransportException {
     // stack trace is meaningless...
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/NotSerializableTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/NotSerializableTransportException.java
@@ -19,7 +19,7 @@ public class NotSerializableTransportException extends TransportException {
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -35,7 +35,7 @@ public class RemoteTransportException extends ActionTransportException implement
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         // no need for stack trace here, we always have cause
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ResponseHandlerFailureTransportException.java
@@ -26,7 +26,7 @@ public class ResponseHandlerFailureTransportException extends TransportException
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     } // why is this?
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/MockSinglePrioritizingExecutor.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/MockSinglePrioritizingExecutor.java
@@ -23,7 +23,7 @@ public class MockSinglePrioritizingExecutor extends PrioritizedEsThreadPoolExecu
         super(name, 0, 1, 0L, TimeUnit.MILLISECONDS,
             r -> new Thread() {
                 @Override
-                public void start() {
+                public synchronized void start() {
                     deterministicTaskQueue.scheduleNow(new Runnable() {
                         @Override
                         public void run() {

--- a/test/framework/src/main/java/org/elasticsearch/test/disruption/IntermittentLongGCDisruption.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/disruption/IntermittentLongGCDisruption.java
@@ -40,7 +40,7 @@ public class IntermittentLongGCDisruption extends LongGCDisruption {
     static final AtomicInteger thread_ids = new AtomicInteger();
 
     @Override
-    public void startDisrupting() {
+    public synchronized void startDisrupting() {
         disrupting = true;
         worker = new Thread(new BackgroundWorker(), "long_gc_simulation_" + thread_ids.incrementAndGet());
         worker.setDaemon(true);
@@ -48,7 +48,7 @@ public class IntermittentLongGCDisruption extends LongGCDisruption {
     }
 
     @Override
-    public void stopDisrupting() {
+    public synchronized void stopDisrupting() {
         if (worker == null) {
             return;
         }

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/BufferOnMarkInputStream.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/BufferOnMarkInputStream.java
@@ -258,7 +258,7 @@ public final class BufferOnMarkInputStream extends InputStream {
      * @see     java.io.InputStream#mark(int)
      */
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         // readlimit is otherwise ignored but this defensively fails if the caller is expecting to be able to mark/reset more than this
         // instance can accommodate in the fixed ring buffer
         if (readlimit > ringBuffer.getBufferSize()) {
@@ -295,7 +295,7 @@ public final class BufferOnMarkInputStream extends InputStream {
      * @see java.io.InputStream#mark(int)
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         ensureOpen();
         if (false == storeToBuffer) {
             throw new IOException("Mark not called or has been invalidated");

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/ChainingInputStream.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/ChainingInputStream.java
@@ -320,7 +320,7 @@ public abstract class ChainingInputStream extends InputStream {
      * @see     java.io.InputStream#mark(int)
      */
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         if (markSupported() && false == closed) {
             // closes any previously stored mark input stream
             if (markIn != null && markIn != EXHAUSTED_MARKER && currentIn != markIn) {
@@ -361,7 +361,7 @@ public abstract class ChainingInputStream extends InputStream {
      * @see     java.io.InputStream#mark(int)
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         ensureOpen();
         if (false == markSupported()) {
             throw new IOException("Mark/reset not supported");

--- a/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/PrefixInputStream.java
+++ b/x-pack/plugin/repository-encrypted/src/main/java/org/elasticsearch/repositories/encrypted/PrefixInputStream.java
@@ -118,12 +118,12 @@ public final class PrefixInputStream extends InputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         // mark and reset are not supported
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         throw new IOException("mark/reset not supported");
     }
 


### PR DESCRIPTION
Add all last synchronization to methods suggested by Sonarqube for the whole project, in order to match with synchronization of parent method or complementary methods. Then, all warnings about "synchronization of methods" should have been fixed.