### PR TITLE
Cast one operand in some operations to avoid unexpected results (1)

### DIFF
--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1385,7 +1385,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         // Installing plugins at config time and loading them when nods start requires additional time we need to
         // account for
             ADDITIONAL_CONFIG_TIMEOUT_UNIT.toMillis(
-                ADDITIONAL_CONFIG_TIMEOUT * (plugins.size() + keystoreFiles.size() + keystoreSettings.size() + credentials.size())
+                (long) ADDITIONAL_CONFIG_TIMEOUT * (plugins.size() + keystoreFiles.size() + keystoreSettings.size() + credentials.size())
             ), TimeUnit.MILLISECONDS, this);
     }
 

--- a/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/buildSrc/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -50,7 +50,7 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
                         TESTCLUSTERS_INSPECT_FAILURE
                     );
                     try {
-                        Thread.sleep(1000 * i);
+                        Thread.sleep(1000 * (long) i);
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         return;

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/AbstractBenchmark.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/AbstractBenchmark.java
@@ -64,7 +64,7 @@ public abstract class AbstractBenchmark<T extends Closeable> {
         float totalDocs = Float.valueOf(args[5]);
         int bulkSize = Integer.valueOf(args[6]);
 
-        int totalIterationCount = (int) Math.ceil(totalDocs / bulkSize);
+        int totalIterationCount = (int) Math.ceil( (double) totalDocs / bulkSize);
         // consider 40% of all iterations as warmup iterations
         int warmupIterations = (int) (0.4d * totalIterationCount);
         int iterations = totalIterationCount - warmupIterations;

--- a/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/metrics/MetricsCalculator.java
+++ b/client/benchmark/src/main/java/org/elasticsearch/client/benchmark/metrics/MetricsCalculator.java
@@ -55,7 +55,7 @@ public final class MetricsCalculator {
                 samples.stream().filter((r) -> r.isSuccess()).count(),
                 samples.stream().filter((r) -> r.isSuccess() == false).count(),
                 // throughput calculation is based on the total (Wall clock) time it took to generate all samples
-                calculateThroughput(samples.size(), latestEnd - firstStart),
+                calculateThroughput(samples.size(), (double) latestEnd - firstStart),
                 // convert ns -> ms without losing precision
                 StatUtils.percentile(serviceTimes, 50.0d) / TimeUnit.MILLISECONDS.toNanos(1L),
                 StatUtils.percentile(serviceTimes, 90.0d) / TimeUnit.MILLISECONDS.toNanos(1L),

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/xpack/XPackInfoResponse.java
@@ -31,7 +31,7 @@ public class XPackInfoResponse {
     /**
      * Value of the license's expiration time if it should never expire.
      */
-    public static final long BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS = Long.MAX_VALUE - TimeUnit.HOURS.toMillis(24 * 365);
+    public static final long BASIC_SELF_GENERATED_LICENSE_EXPIRATION_MILLIS = Long.MAX_VALUE - TimeUnit.HOURS.toMillis( (long) 24 * 365);
     // TODO move this constant to License.java once we move License.java to the protocol jar
 
     @Nullable private BuildInfo buildInfo;

--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/MachineDependentHeap.java
@@ -37,7 +37,7 @@ public final class MachineDependentHeap {
     private static final long GB = 1024L * 1024L * 1024L; // 1GB
     private static final long MAX_HEAP_SIZE = GB * 31; // 31GB
     private static final long MAX_ML_HEAP_SIZE = GB * 2; // 2GB
-    private static final long MIN_HEAP_SIZE = 1024 * 1024 * 128; // 128MB
+    private static final long MIN_HEAP_SIZE = 1024 * (long) 1024 * 128; // 128MB
     private static final int DEFAULT_HEAP_SIZE_MB = 1024;
     private static final String ELASTICSEARCH_YML = "elasticsearch.yml";
 

--- a/libs/geo/src/main/java/org/elasticsearch/geometry/utils/Geohash.java
+++ b/libs/geo/src/main/java/org/elasticsearch/geometry/utils/Geohash.java
@@ -47,8 +47,8 @@ public class Geohash {
     static {
         precisionToLatHeight = new double[PRECISION + 1];
         precisionToLonWidth = new double[PRECISION + 1];
-        precisionToLatHeight[0] = 90*2;
-        precisionToLonWidth[0] = 180*2;
+        precisionToLatHeight[0] = (double) 90*2;
+        precisionToLonWidth[0] = (double) 180*2;
         boolean even = false;
         for(int i = 1; i <= PRECISION; i++) {
             precisionToLatHeight[i] = precisionToLatHeight[i-1] / (even ? 8 : 4);

--- a/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
+++ b/modules/aggs-matrix-stats/src/main/java/org/elasticsearch/search/aggregations/matrix/stats/RunningStats.java
@@ -258,7 +258,7 @@ public class RunningStats implements Writeable, Cloneable {
             d2 = d * d;                 // delta mean squared
             d3 = d * d2;                // delta mean cubed
             d4 = d2 * d2;               // delta mean 4th power
-            n2 = docCount * docCount;   // num samples squared
+            n2 = (double) docCount * docCount;   // num samples squared
             nA2 = nA * nA;              // doc A num samples squared
             nB2 = nB * nB;              // doc B num samples squared
             // variance
@@ -276,7 +276,7 @@ public class RunningStats implements Writeable, Cloneable {
 
     /** Merges two covariance matrices */
     private void mergeCovariance(final RunningStats other, final Map<String, Double> deltas) {
-        final double countA = docCount - other.docCount;
+        final double countA = (double) docCount - other.docCount;
         double f, dR, newVal;
         for (Map.Entry<String, Double> fs : other.means.entrySet()) {
             final String fieldName = fs.getKey();

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGain.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/DiscountedCumulativeGain.java
@@ -156,7 +156,7 @@ public class DiscountedCumulativeGain implements EvaluationMetric {
         double dcg = 0;
         for (Integer rating : ratings) {
             if (rating != null) {
-                dcg += (Math.pow(2, rating) - 1) / ((Math.log(rank + 1) / LOG2));
+                dcg += (Math.pow(2, rating) - 1) / ((Math.log((double) rank + 1) / LOG2));
             }
             rank++;
         }


### PR DESCRIPTION
In some operations (addition, subtraction, multiplication, division), one operand needs to be cast (into long, double ...) to avoid unexpected behavior or result (imprecision, errors of round numbers ...)