### PR TITLE
Casts of one operand in 30+ files to avoid unexpected results (2)

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -107,7 +107,7 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
              * The tradeoff is between less (but larger) buffers that are contained in the CompositeByteBuf and more (but smaller) buffers.
              * With the default max content length of 100MB and a MTU of 1500 bytes we would allow 69905 entries.
              */
-            long maxBufferComponentsEstimate = Math.round((double) (maxContentLength.getBytes() / MTU.getBytes()));
+            long maxBufferComponentsEstimate = Math.round((double) ((double) maxContentLength.getBytes() / MTU.getBytes()));
             // clamp value to the allowed range
             long maxBufferComponents = Math.max(2, Math.min(maxBufferComponentsEstimate, Integer.MAX_VALUE));
             return String.valueOf(maxBufferComponents);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/NettyAllocator.java
@@ -40,7 +40,7 @@ public class NettyAllocator {
     static {
         if (Booleans.parseBoolean(System.getProperty(USE_NETTY_DEFAULT), false)) {
             ALLOCATOR = ByteBufAllocator.DEFAULT;
-            SUGGESTED_MAX_ALLOCATION_SIZE = 1024 * 1024;
+            SUGGESTED_MAX_ALLOCATION_SIZE = (long) 1024 * 1024;
             DESCRIPTION = "[name=netty_default, suggested_max_allocation_size=" + new ByteSizeValue(SUGGESTED_MAX_ALLOCATION_SIZE)
                 + ", factors={es.unsafe.use_netty_default_allocator=true}]";
         } else {
@@ -57,9 +57,9 @@ public class NettyAllocator {
                 if (g1gcEnabled && g1gcRegionSizeIsKnown) {
                     // Suggested max allocation size 1/4 of region size. Guard against unknown edge cases
                     // where this value would be less than 256KB.
-                    SUGGESTED_MAX_ALLOCATION_SIZE = Math.max(g1gcRegionSizeInBytes >> 2, 256 * 1024);
+                    SUGGESTED_MAX_ALLOCATION_SIZE = Math.max(g1gcRegionSizeInBytes >> 2, (long) 256 * 1024);
                 } else {
-                    SUGGESTED_MAX_ALLOCATION_SIZE = 1024 * 1024;
+                    SUGGESTED_MAX_ALLOCATION_SIZE = (long) 1024 * 1024;
                 }
                 DESCRIPTION = "[name=unpooled, suggested_max_allocation_size=" + new ByteSizeValue(SUGGESTED_MAX_ALLOCATION_SIZE)
                     + ", factors={es.unsafe.use_unpooled_allocator=" + System.getProperty(USE_UNPOOLED)

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IndexableBinaryStringTools.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IndexableBinaryStringTools.java
@@ -88,7 +88,7 @@ public final class IndexableBinaryStringTools {
     } else {
       // Use long for intermediaries to protect against overflow
       final long numFullBytesInFinalChar = encoded[offset + length - 1];
-      final long numEncodedChars = numChars - 1;
+      final long numEncodedChars = (long) numChars - 1;
       return (int)((numEncodedChars * 15L + 7L) / 8L + numFullBytesInFinalChar);
     }
   }

--- a/plugins/examples/custom-significance-heuristic/src/main/java/org/elasticsearch/example/customsigheuristic/SimpleHeuristic.java
+++ b/plugins/examples/custom-significance-heuristic/src/main/java/org/elasticsearch/example/customsigheuristic/SimpleHeuristic.java
@@ -74,6 +74,6 @@ public class SimpleHeuristic extends SignificanceHeuristic {
      */
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
-        return subsetFreq / subsetSize > supersetFreq / supersetSize ? 2.0 : 1.0;
+        return (double) subsetFreq / subsetSize > (double) supersetFreq / supersetSize ? 2.0 : 1.0;
     }
 }

--- a/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponseCreator.java
+++ b/plugins/transport-nio/src/main/java/org/elasticsearch/http/nio/NioHttpResponseCreator.java
@@ -54,6 +54,6 @@ public class NioHttpResponseCreator extends MessageToMessageEncoder<NioHttpRespo
     }
 
     private static long suggestedMaxAllocationSize() {
-        return Math.max(Math.max(JvmInfo.jvmInfo().getG1RegionSize(), 0) >> 2, 256 * 1024);
+        return Math.max(Math.max(JvmInfo.jvmInfo().getG1RegionSize(), 0) >> 2, (long) 256 * 1024);
     }
 }

--- a/server/src/main/java/org/apache/lucene/analysis/miscellaneous/DuplicateByteSequenceSpotter.java
+++ b/server/src/main/java/org/apache/lucene/analysis/miscellaneous/DuplicateByteSequenceSpotter.java
@@ -68,7 +68,7 @@ public class DuplicateByteSequenceSpotter {
     private long bytesAllocated;
     // Root node object plus inner-class reference to containing "this"
     // (profiler suggested this was a cost)
-    static final long TREE_NODE_OBJECT_SIZE = RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+    static final long TREE_NODE_OBJECT_SIZE = (long) RamUsageEstimator.NUM_BYTES_OBJECT_HEADER + RamUsageEstimator.NUM_BYTES_OBJECT_REF;
     // A TreeNode specialization with an array ref (dynamically allocated and
     // fixed-size)
     static final long ROOT_TREE_NODE_OBJECT_SIZE = TREE_NODE_OBJECT_SIZE + RamUsageEstimator.NUM_BYTES_OBJECT_REF;

--- a/server/src/main/java/org/apache/lucene/queries/MinDocQuery.java
+++ b/server/src/main/java/org/apache/lucene/queries/MinDocQuery.java
@@ -132,7 +132,7 @@ public final class MinDocQuery extends Query {
 
         @Override
         public long cost() {
-            return maxDoc - segmentMinDoc;
+            return (long) maxDoc - segmentMinDoc;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -145,8 +145,8 @@ final class SystemCallFilter {
         SockFProg(SockFilter filters[]) {
             len = (short) filters.length;
             // serialize struct sock_filter * explicitly, its less confusing than the JNA magic we would need
-            Memory filter = new Memory(len * 8);
-            ByteBuffer bbuf = filter.getByteBuffer(0, len * 8);
+            Memory filter = new Memory((long) len * 8);
+            ByteBuffer bbuf = filter.getByteBuffer(0, (long) len * 8);
             bbuf.order(ByteOrder.nativeOrder()); // little endian
             for (SockFilter f : filters) {
                 bbuf.putShort(f.code);

--- a/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
+++ b/server/src/main/java/org/elasticsearch/common/LocalTimeOffset.java
@@ -530,13 +530,13 @@ public abstract class LocalTimeOffset {
         }
 
         protected static NoPrevious buildNoPrevious(ZoneOffsetTransition transition) {
-            return new NoPrevious(transition.getOffsetBefore().getTotalSeconds() * 1000);
+            return new NoPrevious((long) transition.getOffsetBefore().getTotalSeconds() * 1000);
         }
 
         protected static Transition buildTransition(ZoneOffsetTransition transition, LocalTimeOffset previous) {
             long utcStart = transition.toEpochSecond() * 1000;
-            long offsetBeforeMillis = transition.getOffsetBefore().getTotalSeconds() * 1000;
-            long offsetAfterMillis = transition.getOffsetAfter().getTotalSeconds() * 1000;
+            long offsetBeforeMillis = (long) transition.getOffsetBefore().getTotalSeconds() * 1000;
+            long offsetAfterMillis = (long) transition.getOffsetAfter().getTotalSeconds() * 1000;
             assert (false == previous instanceof Transition) || ((Transition) previous).startUtcMillis < utcStart :
                     "transition list out of order at [" + previous + "] and [" + transition + "]";
             assert previous.millis != offsetAfterMillis :
@@ -574,7 +574,7 @@ public abstract class LocalTimeOffset {
         if (false == rules.isFixedOffset()) {
             return null;
         }
-        LocalTimeOffset fixedTransition = new NoPrevious(rules.getOffset(Instant.EPOCH).getTotalSeconds() * 1000);
+        LocalTimeOffset fixedTransition = new NoPrevious((long) rules.getOffset(Instant.EPOCH).getTotalSeconds() * 1000);
         return fixedTransition;
     }
 

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -37,7 +37,7 @@ public class PagedBytesReference extends AbstractBytesReference {
 
     @Override
     public byte get(int index) {
-        return byteArray.get(offset + index);
+        return byteArray.get((long) offset + index);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class PagedBytesReference extends AbstractBytesReference {
             @Override
             public BytesRef next() throws IOException {
                 if (nextFragmentSize != 0) {
-                    final boolean materialized = byteArray.get(offset + position, nextFragmentSize, slice);
+                    final boolean materialized = byteArray.get((long) offset + position, nextFragmentSize, slice);
                     assert materialized == false : "iteration should be page aligned but array got materialized";
                     position += nextFragmentSize;
                     final int remaining = length - position;

--- a/server/src/main/java/org/elasticsearch/common/bytes/RecyclingBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/RecyclingBytesStreamOutput.java
@@ -47,7 +47,7 @@ public class RecyclingBytesStreamOutput extends BytesStream {
             buffer[position++] = b;
         } else {
             ensureCapacity(position + 1);
-            overflow.set(position++ - buffer.length, b);
+            overflow.set((long) position++ - buffer.length, b);
         }
     }
 
@@ -76,7 +76,7 @@ public class RecyclingBytesStreamOutput extends BytesStream {
 
         if (length > 0) {
             ensureCapacity(position + length);
-            overflow.set(position - buffer.length, b, offset, length);
+            overflow.set((long) position - buffer.length, b, offset, length);
             position += length;
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoUtils.java
@@ -92,7 +92,7 @@ public class GeoUtils {
         assert level>=0;
         // Geohash cells are split into 32 cells at each level. the grid
         // alternates at each level between a 8x4 and a 4x8 grid
-        return EARTH_EQUATOR / (1L<<((((level+1)/2)*3) + ((level/2)*2)));
+        return EARTH_EQUATOR / (1L<<((((double) (level+1)/2)*3) + (((double) level/2)*2)));
     }
 
     /**
@@ -114,7 +114,7 @@ public class GeoUtils {
         assert level>=0;
         // Geohash cells are split into 32 cells at each level. the grid
         // alternates at each level between a 8x4 and a 4x8 grid
-        return EARTH_POLAR_DISTANCE / (1L<<((((level+1)/2)*2) + ((level/2)*3)));
+        return EARTH_POLAR_DISTANCE / (1L<<((((double) (level+1)/2)*2) + (((double) level/2)*3)));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaDateMathParser.java
@@ -124,7 +124,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusYears(1);
                         }
                     } else {
-                        dateTime = dateTime.plusYears(sign * num);
+                        dateTime = dateTime.plusYears((long) sign * num);
                     }
                     break;
                 case 'M':
@@ -134,7 +134,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusMonths(1);
                         }
                     } else {
-                        dateTime = dateTime.plusMonths(sign * num);
+                        dateTime = dateTime.plusMonths((long) sign * num);
                     }
                     break;
                 case 'w':
@@ -144,7 +144,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusWeeks(1);
                         }
                     } else {
-                        dateTime = dateTime.plusWeeks(sign * num);
+                        dateTime = dateTime.plusWeeks((long) sign * num);
                     }
                     break;
                 case 'd':
@@ -154,7 +154,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusDays(1);
                         }
                     } else {
-                        dateTime = dateTime.plusDays(sign * num);
+                        dateTime = dateTime.plusDays((long) sign * num);
                     }
                     break;
                 case 'h':
@@ -165,7 +165,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusHours(1);
                         }
                     } else {
-                        dateTime = dateTime.plusHours(sign * num);
+                        dateTime = dateTime.plusHours((long) sign * num);
                     }
                     break;
                 case 'm':
@@ -175,7 +175,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusMinutes(1);
                         }
                     } else {
-                        dateTime = dateTime.plusMinutes(sign * num);
+                        dateTime = dateTime.plusMinutes((long) sign * num);
                     }
                     break;
                 case 's':
@@ -185,7 +185,7 @@ public class JavaDateMathParser implements DateMathParser {
                             dateTime = dateTime.plusSeconds(1);
                         }
                     } else {
-                        dateTime = dateTime.plusSeconds(sign * num);
+                        dateTime = dateTime.plusSeconds((long) sign * num);
                     }
                     break;
                 default:

--- a/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/CollectionUtils.java
@@ -331,7 +331,7 @@ public class CollectionUtils {
         if (size <= 0) {
             throw new IllegalArgumentException("size <= 0");
         }
-        List<List<E>> result = new ArrayList<>((int) Math.ceil(list.size() / size));
+        List<List<E>> result = new ArrayList<>((int) Math.ceil((double) list.size() / size));
 
         List<E> accumulator = new ArrayList<>(size);
         int count = 0;

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -145,6 +145,6 @@ public final class LongLongHash extends AbstractHash {
     }
 
     static long hash(long key1, long key2) {
-        return 31 * BitMixer.mix(key1) +  BitMixer.mix(key2);
+        return 31 * BitMixer.mix(key1) + (long)  BitMixer.mix(key2);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -179,7 +179,7 @@ public final class IndexSettings {
              * can get stuck in an infinite loop as the shouldPeriodicallyFlush can still be true after flushing.
              * However, small thresholds are useful for testing so we do not add a large lower bound here.
              */
-            new ByteSizeValue(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
+            new ByteSizeValue((long) Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
             new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
             Property.Dynamic, Property.IndexScope);
 
@@ -206,7 +206,7 @@ public final class IndexSettings {
                      * generation threshold. However, small thresholds are useful for testing so we
                      * do not add a large lower bound here.
                      */
-                    new ByteSizeValue(Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
+                    new ByteSizeValue((long) Translog.DEFAULT_HEADER_SIZE_IN_BYTES + 1, ByteSizeUnit.BYTES),
                     new ByteSizeValue(Long.MAX_VALUE, ByteSizeUnit.BYTES),
                     Property.Dynamic, Property.IndexScope);
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/RamAccountingTermsEnum.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/RamAccountingTermsEnum.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 public final class RamAccountingTermsEnum extends FilteredTermsEnum {
 
     // Flush every 5mb
-    private static final long FLUSH_BUFFER_SIZE = 1024 * 1024 * 5;
+    private static final long FLUSH_BUFFER_SIZE = 1024 * (long) 1024 * 5;
 
     private final CircuitBreaker breaker;
     private final TermsEnum termsEnum;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/MultiOrdinals.java
@@ -125,7 +125,7 @@ public class MultiOrdinals extends Ordinals {
         @Override
         public boolean advanceExact(int docId) throws IOException {
             currentDoc = docId;
-            currentStartOffset = docId != 0 ? endOffsets.get(docId - 1) : 0;
+            currentStartOffset = docId != 0 ? endOffsets.get((long) docId - 1) : 0;
             currentEndOffset = endOffsets.get(docId);
             return currentStartOffset != currentEndOffset;
         }
@@ -171,7 +171,7 @@ public class MultiOrdinals extends Ordinals {
 
         @Override
         public boolean advanceExact(int docId) throws IOException {
-            currentOffset = docId != 0 ? endOffsets.get(docId - 1) : 0;
+            currentOffset = docId != 0 ? endOffsets.get((long) docId - 1) : 0;
             currentEndOffset = endOffsets.get(docId);
             return currentOffset != currentEndOffset;
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/OrdinalsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ordinals/OrdinalsBuilder.java
@@ -153,7 +153,7 @@ public final class OrdinalsBuilder implements Closeable {
             if (ordinals[level] == null) {
                 ordinals[level] = new PagedGrowableWriter(8L * numSlots(level), PAGE_SIZE, startBitsPerValue, acceptableOverheadRatio);
             } else {
-                ordinals[level] = ordinals[level].grow(sizes[level] * numSlots(level));
+                ordinals[level] = ordinals[level].grow((long) sizes[level] * numSlots(level));
                 if (nextLevelSlices[level] != null) {
                     nextLevelSlices[level] = nextLevelSlices[level].grow(sizes[level]);
                 }

--- a/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/InnerHitContextBuilder.java
@@ -38,7 +38,7 @@ public abstract class InnerHitContextBuilder {
     }
 
     public final void build(SearchContext parentSearchContext, InnerHitsContext innerHitsContext) throws IOException {
-        long innerResultWindow = innerHitBuilder.getFrom() + innerHitBuilder.getSize();
+        long innerResultWindow = (long) innerHitBuilder.getFrom() + innerHitBuilder.getSize();
         int maxInnerResultWindow = parentSearchContext.getSearchExecutionContext().getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -902,7 +902,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
          * Computes a strong hash value for small files. Note that this method should only be used for files &lt; 1MB
          */
         public static void hashFile(BytesRefBuilder fileHash, InputStream in, long size) throws IOException {
-            final int len = (int) Math.min(1024 * 1024, size); // for safety we limit this to 1MB
+            final int len = (int) Math.min((long) 1024 * 1024, size); // for safety we limit this to 1MB
             fileHash.grow(len);
             fileHash.setLength(len);
             final int readBytes = Streams.readFully(in, fileHash.bytes(), 0, len);

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1155,7 +1155,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             return (2 * id.length())
                 + source.length()
                 + (routing != null ? 2 * routing.length() : 0)
-                + (4 * Long.BYTES); // timestamp, seq_no, primary_term, and version
+                + (long) (4 * Long.BYTES); // timestamp, seq_no, primary_term, and version
         }
 
         public String id() {
@@ -1319,7 +1319,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         @Override
         public long estimateSize() {
             return (2 * id.length())
-                + (3 * Long.BYTES); // seq_no, primary_term, and version;
+                + (long) (3 * Long.BYTES); // seq_no, primary_term, and version;
         }
 
         public String id() {
@@ -1448,7 +1448,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
 
         @Override
         public long estimateSize() {
-            return 2 * reason.length() + 2 * Long.BYTES;
+            return (long) 2 * reason.length() + 2 * Long.BYTES;
         }
 
         @Override
@@ -1533,7 +1533,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
                 // to prevent this unfortunately.
                 in.mark(opSize);
 
-                in.skip(opSize - 4);
+                in.skip((long) opSize - 4);
                 verifyChecksum(in);
                 in.reset();
             }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1201,7 +1201,7 @@ public class IndicesService extends AbstractLifecycleComponent
             if (remove != null && remove.isEmpty() == false) {
                 numRemoved = remove.size();
                 CollectionUtil.timSort(remove); // make sure we delete indices first
-                final long maxSleepTimeMs = 10 * 1000; // ensure we retry after 10 sec
+                final long maxSleepTimeMs = (long) 10 * 1000; // ensure we retry after 10 sec
                 long sleepTime = 10;
                 do {
                     if (remove.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/node/ResponseCollectorService.java
+++ b/server/src/main/java/org/elasticsearch/node/ResponseCollectorService.java
@@ -152,7 +152,7 @@ public final class ResponseCollectorService implements ClusterStateListener {
             // the concurrency compensation is defined as the number of
             // outstanding requests from the client to the node times the number
             // of clients in the system
-            double concurrencyCompensation = outstandingRequests * clientNum;
+            double concurrencyCompensation = (double) outstandingRequests * clientNum;
 
             // Cubic queue adjustment factor. The paper chose 3 though we could
             // potentially make this configurable if desired.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public abstract class AggregationBuilder
         implements NamedWriteable, ToXContentFragment, BaseAggregationBuilder, Rewriteable<AggregationBuilder> {
-    public static final long DEFAULT_PREALLOCATION = 1024 * 6;
+    public static final long DEFAULT_PREALLOCATION = (long) 1024 * 6;
 
     protected final String name;
     protected AggregatorFactories.Builder factoriesBuilder = AggregatorFactories.builder();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -123,7 +123,7 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                     docDeltasBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
                     bucketsBuilder = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
                 }
-                docDeltasBuilder.add(doc - lastDoc);
+                docDeltasBuilder.add((long) doc - lastDoc);
                 bucketsBuilder.add(bucket);
                 lastDoc = doc;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/BinaryValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/BinaryValuesSource.java
@@ -49,8 +49,8 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
 
     @Override
     void copyCurrent(int slot) {
-        values =  bigArrays.grow(values, slot+1);
-        valueBuilders = bigArrays.grow(valueBuilders, slot+1);
+        values =  bigArrays.grow(values, (long) slot+1);
+        valueBuilders = bigArrays.grow(valueBuilders, (long) slot+1);
         BytesRefBuilder builder = valueBuilders.get(slot);
         int byteSize = builder == null ? 0 : builder.bytes().length;
         if (builder == null) {
@@ -62,7 +62,7 @@ class BinaryValuesSource extends SingleDimensionValuesSource<BytesRef> {
         } else {
             assert currentValue != null;
             builder.copyBytes(currentValue);
-            breakerConsumer.accept(builder.bytes().length - byteSize);
+            breakerConsumer.accept((long) builder.bytes().length - byteSize);
             values.set(slot, builder.get());
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
@@ -135,7 +135,7 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
         for (int i = 0; i < arrays.length; i++) {
             arrays[i].copyCurrent(slot);
         }
-        docCounts = bigArrays.grow(docCounts, slot+1);
+        docCounts = bigArrays.grow(docCounts, (long) slot+1);
         docCounts.set(slot, value);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DoubleValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/DoubleValuesSource.java
@@ -44,7 +44,7 @@ class DoubleValuesSource extends SingleDimensionValuesSource<Double> {
 
     @Override
     void copyCurrent(int slot) {
-        values = bigArrays.grow(values, slot+1);
+        values = bigArrays.grow(values, (long) slot+1);
         if (missingBucket && missingCurrentValue) {
             bits.clear(slot);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/GlobalOrdinalValuesSource.java
@@ -51,7 +51,7 @@ class GlobalOrdinalValuesSource extends SingleDimensionValuesSource<BytesRef> {
 
     @Override
     void copyCurrent(int slot) {
-        values = bigArrays.grow(values, slot+1);
+        values = bigArrays.grow(values, (long) slot+1);
         values.set(slot, currentValue);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -61,7 +61,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
 
     @Override
     void copyCurrent(int slot) {
-        values = bigArrays.grow(values, slot+1);
+        values = bigArrays.grow(values, (long) slot+1);
         if (missingBucket && missingCurrentValue) {
             bits.clear(slot);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
@@ -97,7 +97,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
         public CollectionPhase collectValue(LeafBucketCollector sub, int doc, double val) throws IOException{
             if (bufferSize < bufferLimit) {
                 // Add to the buffer i.e store the doc in a new bucket
-                buffer = bigArrays().grow(buffer, bufferSize + 1);
+                buffer = bigArrays().grow(buffer, (long) bufferSize + 1);
                 buffer.set((long) bufferSize, val);
                 collectBucket(sub, doc, bufferSize);
                 bufferSize += 1;
@@ -255,7 +255,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
             }
 
             LongUnaryOperator howToRewrite = b -> mergeMap[(int) b];
-            rewriteBuckets(bucketOrd + 1, howToRewrite);
+            rewriteBuckets((long) bucketOrd + 1, howToRewrite);
             if (deferringCollector != null) {
                 deferringCollector.rewriteBuckets(howToRewrite);
             }
@@ -270,7 +270,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
                 // TODO: (maybe) Create a new bucket for <b>all</b> distant docs and merge down to shardSize buckets at end
 
                 createAndAppendNewCluster(val);
-                collectBucket(sub, doc, numClusters - 1);
+                collectBucket(sub, doc, (long) numClusters - 1);
 
                 if(val > clusterCentroids.get(bucketOrd)){
                     /*
@@ -295,7 +295,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
 
         private void updateAvgBucketDistance() {
             // Centroids are sorted so the average distance is the difference between the first and last.
-            avgBucketDistance = (clusterCentroids.get(numClusters - 1) - clusterCentroids.get(0)) / (numClusters - 1);
+            avgBucketDistance = (clusterCentroids.get((long) numClusters - 1) - clusterCentroids.get(0)) / (numClusters - 1);
         }
 
         /**
@@ -303,10 +303,10 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
          */
         private void createAndAppendNewCluster(double value){
             // Ensure there is space for the cluster
-            clusterMaxes = bigArrays().grow(clusterMaxes, numClusters + 1); //  + 1 because indexing starts at 0
-            clusterMins = bigArrays().grow(clusterMins, numClusters + 1);
-            clusterCentroids = bigArrays().grow(clusterCentroids, numClusters + 1);
-            clusterSizes = bigArrays().grow(clusterSizes, numClusters + 1);
+            clusterMaxes = bigArrays().grow(clusterMaxes, (long) numClusters + 1); //  + 1 because indexing starts at 0
+            clusterMins = bigArrays().grow(clusterMins, (long) numClusters + 1);
+            clusterCentroids = bigArrays().grow(clusterCentroids, (long) numClusters + 1);
+            clusterSizes = bigArrays().grow(clusterSizes, (long) numClusters + 1);
 
             // Initialize the cluster at the end of the array
             clusterMaxes.set(numClusters, value);
@@ -327,16 +327,16 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
             if(index != numClusters - 1) {
 
                 // Move the cluster metadata
-                double holdMax = clusterMaxes.get(numClusters-1);
-                double holdMin = clusterMins.get(numClusters-1);
-                double holdCentroid = clusterCentroids.get(numClusters-1);
-                double holdSize = clusterSizes.get(numClusters-1);
+                double holdMax = clusterMaxes.get((long) numClusters-1);
+                double holdMin = clusterMins.get((long) numClusters-1);
+                double holdCentroid = clusterCentroids.get((long) numClusters-1);
+                double holdSize = clusterSizes.get((long) numClusters-1);
                 for (int i = numClusters - 1; i > index; i--) {
                     // The clusters in range {index ... numClusters - 1} move up 1 index to make room for the new cluster
-                    clusterMaxes.set(i, clusterMaxes.get(i-1));
-                    clusterMins.set(i, clusterMins.get(i-1));
-                    clusterCentroids.set(i, clusterCentroids.get(i-1));
-                    clusterSizes.set(i, clusterSizes.get(i-1));
+                    clusterMaxes.set(i, clusterMaxes.get((long) i-1));
+                    clusterMins.set(i, clusterMins.get((long) i-1));
+                    clusterCentroids.set(i, clusterCentroids.get((long) i-1));
+                    clusterSizes.set(i, clusterSizes.get((long) i-1));
                 }
                 clusterMaxes.set(index, holdMax);
                 clusterMins.set(index, holdMin);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/GlobalOrdinalsStringTermsAggregator.java
@@ -319,7 +319,7 @@ public class GlobalOrdinalsStringTermsAggregator extends AbstractStringTermsAggr
                         }
                         int ord = singleValues.ordValue();
                         int docCount = docCountProvider.getDocCount(doc);
-                        segmentDocCounts.increment(ord + 1, docCount);
+                        segmentDocCounts.increment((long) ord + 1, docCount);
                     }
                 });
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/NXYSignificanceHeuristic.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/NXYSignificanceHeuristic.java
@@ -91,42 +91,42 @@ public abstract class NXYSignificanceHeuristic extends SignificanceHeuristic {
         Frequencies frequencies = new Frequencies();
         if (backgroundIsSuperset) {
             //documents not in class and do not contain term
-            frequencies.N00 = supersetSize - supersetFreq - (subsetSize - subsetFreq);
+            frequencies.N00 = supersetSize - (double) supersetFreq - (subsetSize - subsetFreq);
             //documents in class and do not contain term
             frequencies.N01 = (subsetSize - subsetFreq);
             // documents not in class and do contain term
-            frequencies.N10 = supersetFreq - subsetFreq;
+            frequencies.N10 = (double) supersetFreq - subsetFreq;
             // documents in class and do contain term
             frequencies.N11 = subsetFreq;
             //documents that do not contain term
-            frequencies.N0_ = supersetSize - supersetFreq;
+            frequencies.N0_ = (double) supersetSize - supersetFreq;
             //documents that contain term
             frequencies.N1_ = supersetFreq;
             //documents that are not in class
-            frequencies.N_0 = supersetSize - subsetSize;
+            frequencies.N_0 = (double) supersetSize - subsetSize;
             //documents that are in class
             frequencies.N_1 = subsetSize;
             //all docs
             frequencies.N = supersetSize;
         } else {
             //documents not in class and do not contain term
-            frequencies.N00 = supersetSize - supersetFreq;
+            frequencies.N00 = (double) supersetSize - supersetFreq;
             //documents in class and do not contain term
-            frequencies.N01 = subsetSize - subsetFreq;
+            frequencies.N01 = (double) subsetSize - subsetFreq;
             // documents not in class and do contain term
             frequencies.N10 = supersetFreq;
             // documents in class and do contain term
             frequencies.N11 = subsetFreq;
             //documents that do not contain term
-            frequencies.N0_ = supersetSize - supersetFreq + subsetSize - subsetFreq;
+            frequencies.N0_ = supersetSize - supersetFreq + (double) subsetSize - subsetFreq;
             //documents that contain term
-            frequencies.N1_ = supersetFreq + subsetFreq;
+            frequencies.N1_ = (double) supersetFreq + subsetFreq;
             //documents that are not in class
             frequencies.N_0 = supersetSize;
             //documents that are in class
             frequencies.N_1 = subsetSize;
             //all docs
-            frequencies.N = supersetSize + subsetSize;
+            frequencies.N = (double) supersetSize + subsetSize;
         }
         return frequencies;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -42,7 +42,7 @@ class ScriptedMetricAggregator extends MetricsAggregator {
      * inaccurate. We're sort of hoping that the real memory breaker saves
      * us here. Or that folks just don't use the aggregation.
      */
-    private static final long BUCKET_COST_ESTIMATE = 1024 * 5;
+    private static final long BUCKET_COST_ESTIMATE = (long) 1024 * 5;
 
     private final SearchLookup lookup;
     private final Map<String, Object> aggParams;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -600,7 +600,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     @Override
     protected TopHitsAggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subfactoriesBuilder)
             throws IOException {
-        long innerResultWindow = from() + size();
+        long innerResultWindow = (long) from() + size();
         int maxInnerResultWindow = context.getIndexSettings().getMaxInnerResultWindow();
         if (innerResultWindow > maxInnerResultWindow) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/DirectCandidateGenerator.java
@@ -208,7 +208,7 @@ public final class DirectCandidateGenerator extends CandidateGenerator {
     int thresholdTermFrequency(int docFreq) {
         if (docFreq > 0) {
             return (int) min(
-                max(0, round(docFreq * (log10(docFreq - frequencyPlateau) * (1.0 / log10(LOG_BASE))) + 1)), Integer.MAX_VALUE
+                max(0, round(docFreq * (log10((double) docFreq - frequencyPlateau) * (1.0 / log10(LOG_BASE))) + 1)), Integer.MAX_VALUE
             );
         }
         return 0;


### PR DESCRIPTION
In some operations (addition, subtraction, multiplication, division), one operand needs to be cast (into long, double ...) to avoid unexpected behavior or result (imprecision, errors of round numbers ...), in 37 files